### PR TITLE
fix(deploy): ensure k3s is ready before helm install

### DIFF
--- a/production/scripts/install-sealed-secrets.sh
+++ b/production/scripts/install-sealed-secrets.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
 # Instala o controller do Sealed Secrets para gerenciamento seguro de senhas
 echo "==> Adicionando repositório Helm do Sealed Secrets..."
 helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets


### PR DESCRIPTION
The previous script used a fixed `sleep 5` to wait for k3s to start, which was not reliable and caused `helm install` to fail with a "connection refused" error if the cluster was not ready in time.

This commit replaces the fixed sleep with a robust check that:
1. Waits for the `/etc/rancher/k3s/k3s.yaml` kubeconfig file to be created.
2. Actively polls the Kubernetes API server until it is responsive before proceeding.

Additionally, the `KUBECONFIG` environment variable is explicitly exported in `install-sealed-secrets.sh` to ensure Helm can connect to the cluster.