### PR TITLE
fix(ingress): resolve redirect loop and improve security

### DIFF
--- a/production/argocd/apps/ingress-nginx.yaml
+++ b/production/argocd/apps/ingress-nginx.yaml
@@ -40,6 +40,10 @@ spec:
             worker-connections: "16384"
             keep-alive: "75"
             keep-alive-requests: "10000"
+            # Correção para ERR_TOO_MANY_REDIRECTS
+            use-forwarded-headers: "true"
+            # Melhoria de segurança
+            proxy-real-ip-cidr: "10.42.0.0/16"
   syncPolicy:
     automated:
       prune: true

--- a/production/k8s/ingress/camunda-ingresses.yaml
+++ b/production/k8s/ingress/camunda-ingresses.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: camunda
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:


### PR DESCRIPTION
This commit addresses the 'ERR_TOO_MANY_REDIRECTS' error by correctly configuring the Ingress-Nginx controller.

- Enables  to ensure the controller respects proxy headers, which is crucial when running behind an external load balancer.
- Enforces SSL redirection on the Camunda ingress resources.
- Adds the cluster's internal CIDR to  to correctly identify client IP addresses.