### PR TITLE
feat: Habilita o ingress nos valores do Helm

### DIFF
--- a/production/helm-values/camunda/values.yaml
+++ b/production/helm-values/camunda/values.yaml
@@ -5,7 +5,7 @@ global:
   image:
     pullPolicy: IfNotPresent
   ingress:
-    enabled: false
+    enabled: true
     host: consultorunicoon.com.br
     tls:
       enabled: true


### PR DESCRIPTION
Habilita o ingress global nos valores do chart Helm do Camunda.

Isso é necessário para garantir que o serviço de identidade seja configurado com as URIs de redirecionamento públicas corretas, o que corrige o loop de redirecionamento de autenticação.